### PR TITLE
fix: stop compressing release binaries with upx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,39 +6,19 @@ builds:
 
     targets:
       - darwin_amd64
+      - darwin_arm64
       - linux_amd64
 
     flags:
+      - -buildvcs=false
       - -trimpath
 
     ldflags:
       - -s -w
+      - -buildid=
       - -X jdk.sh/meta.date={{ .Date }}
       - -X jdk.sh/meta.sha={{ .Commit }}
       - -X jdk.sh/meta.version={{ .Tag }}
-      - -buildid=
-
-    env:
-      - CGO_ENABLED=0
-
-    hooks:
-      post: upx --best --ultra-brute "{{ .Path }}"
-
-  - id: aws-console-m1
-    binary: aws-console
-
-    targets:
-      - darwin_arm64
-
-    flags:
-      - -trimpath
-
-    ldflags:
-      - -s -w
-      - -X jdk.sh/meta.date={{ .Date }}
-      - -X jdk.sh/meta.sha={{ .Commit }}
-      - -X jdk.sh/meta.version={{ .Tag }}
-      - -buildid=
 
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
This repo has been using [upx/upx](https://github.com/upx/upx) to compress release binaries.

Binaries for darwin-arm64 hav not worked historically, and were never compressed. Recently binaries for darwin-amd64 no longer work for users who have upgraded to macOS Ventura.

See https://github.com/upx/upx/issues/612 for tracking the upstream issue.