### PR TITLE
feat: support for aws govcloud and other partitions

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -22,10 +22,7 @@ import (
 // GenerateLoginURL takes the given sts.Credentials and generates a url.URL
 // that can be used to login to the AWS Console.
 // See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html.
-func GenerateLoginURL(creds *aws.Credentials, duration time.Duration, location, userAgent string) (*url.URL, error) {
-	// federationURL is the url used for AWS federation actions.
-	const federationURL = "https://signin.aws.amazon.com/federation"
-
+func GenerateLoginURL(creds *aws.Credentials, federationURL string, duration time.Duration, location, userAgent string) (*url.URL, error) {
 	// timeout is a hardcoded 15 second window for HTTP requests to complete.
 	const timeout = 15 * time.Second
 

--- a/credentials/partition.go
+++ b/credentials/partition.go
@@ -1,0 +1,43 @@
+// Copyright Josh Komoroske. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// a copy of which can be found in the LICENSE.txt file.
+// SPDX-License-Identifier: MIT
+
+package credentials
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+var partitionURLs = map[string]struct {
+	consoleDomain string
+	federationURL string
+}{
+	"aws": {
+		consoleDomain: "console.aws.amazon.com",
+		federationURL: "https://signin.aws.amazon.com/federation",
+	},
+	"aws-cn": {
+		// This partition has not been tested.
+		consoleDomain: "console.amazonaws.cn",
+		federationURL: "https://signin.amazonaws.cn/federation",
+	},
+	"aws-us-gov": {
+		consoleDomain: "console.amazonaws-us-gov.com",
+		federationURL: "https://signin.amazonaws-us-gov.com/federation",
+	},
+}
+
+// ResolveRegionPartition uses the given AWS region to determine the corresponding AWS partition, Console URL, and federation URL.
+func ResolveRegionPartition(region string) (string, string, string, bool) {
+	partition := "aws"
+	if endpoint, err := sts.NewDefaultEndpointResolver().ResolveEndpoint(region, sts.EndpointResolverOptions{}); err == nil {
+		partition = endpoint.PartitionID
+	}
+
+	if urls, ok := partitionURLs[partition]; ok {
+		return partition, urls.consoleDomain, urls.federationURL, true
+	}
+
+	return "", "", "", false
+}


### PR DESCRIPTION
Determine the AWS partition based on the configured region. This is then used to generate partition-appropriate IAM policy ARNs for use with GetFederationToken, federation URLs, and Console redirect URLs. The built-in list of Console service URLs has also been updated to reflect the current scheme.

Closes #47 